### PR TITLE
add NSM mention to desktop file

### DIFF
--- a/data/jack_mixer.desktop
+++ b/data/jack_mixer.desktop
@@ -10,3 +10,4 @@ Type=Application
 StartupNotify=true
 Categories=GTK;GNOME;AudioVideo;Player;Audio;
 Icon=jack_mixer
+X-NSM-Capable=true


### PR DESCRIPTION
Hi.

This key allows the application to be listed by NSM sessions managers, see https://github.com/jackaudio/new-session-manager/issues/40

RaySession now can list apps with this key (as factory templates).
Please keep the raysession template for the moment, to let previous RS versions list it.